### PR TITLE
Update install.sh

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -8,6 +8,10 @@ if [[ $EUID -eq 0 ]]; then
     echo "Installing system-wide (running as root)"
     mkdir -p /usr/lib/rhythmbox/plugins/lastfmplaycount
     cp * /usr/lib/rhythmbox/plugins/lastfmplaycount
+    if [ -d /usr/share/rhythmbox/plugins ]; then
+        mkdir -p /usr/share/rhythmbox/plugins/lastfmplaycount
+        cp *.ui /usr/share/rhythmbox/plugins/lastfmplaycount
+    fi
 else
     echo "Installing for the current user only"
     mkdir -p ~/.local/share/rhythmbox/plugins/lastfmplaycount


### PR DESCRIPTION
As described here: https://github.com/lotan/rhythmbox-ampache/issues/1#issuecomment-181836945 /usr/share/rhythmbox/plugins is where to find assets (most of the time, therefore the checking for the directory).

If user is installing in home folder then there is no need for changes, but if is installing system wide, and libpeas is built with flag -DDATADIR set to /usr/share/ the ui file needs to be in /usr/share/...

EDIT: this closes issue #12 
